### PR TITLE
feat: add mainnet-community data-node

### DIFF
--- a/mainnet_config.json
+++ b/mainnet_config.json
@@ -101,6 +101,12 @@
 	    "grpc": "tls://vega-grpc.aurora-edge.com:443",
 	    "gql": "https://vega.aurora-edge.com/graphql",
 	    "rest": "https://vega.aurora-edge.com"
+	},
+	{
+	    "name": "mainnet-community",
+	    "grpc": "tls://grpc.vega.mainnet.community:443",
+	    "gql": "https://vega.mainnet.community/graphql",
+	    "rest": "https://vega.mainnet.community"
 	}
     ]
 }


### PR DESCRIPTION
The data-node is running in a private node at my flat. And is exposed via a public gateway hosted in Hetzner

![image](https://github.com/jeremyletang/check_validator_setup/assets/1239637/0a845423-eab5-422a-aac5-adb645858fd0)
